### PR TITLE
Add View should run correct_user_permissions at end, not in middle

### DIFF
--- a/ocdskingfisherviews/cli/commands/add_view.py
+++ b/ocdskingfisherviews/cli/commands/add_view.py
@@ -42,12 +42,15 @@ class AddViewCLICommand(ocdskingfisherviews.cli.commands.base.CLICommand):
 
         if not args.dontbuild:
 
-            logger.info("Correcting User Permissions after Creating View " + args.name)
-            correct_user_permissions(engine)
-
             logger.info("Refreshing Views after Creating View " + args.name)
             refresh_views(engine, viewname=args.name)
 
             logger.info("Updating Field Counts after Creating View " + args.name)
             field_counts = FieldCounts(engine=engine)
             field_counts.run(viewname=args.name)
+
+            # This must be done after table creation in refresh_views and FieldCounts
+            # as the users are granted access to tables that already exist.
+            # So if it's done before, the users won't be able to access some tables!
+            logger.info("Correcting User Permissions after Creating View " + args.name)
+            correct_user_permissions(engine)


### PR DESCRIPTION
Otherwise there is a bug in that access isn't granted to tables created during refresh_views and FieldCounts
https://github.com/open-contracting/kingfisher-views/issues/55