### PR TITLE
All views must be created specially; default views is gone

### DIFF
--- a/docs/cli-field-counts.rst
+++ b/docs/cli-field-counts.rst
@@ -5,24 +5,20 @@ This tool will update the ``field_count`` table.
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli field-counts
+    python ocdskingfisher-views-cli field-counts viewname
+
+You must pass the view name.
 
 To remove the table run:
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli field-counts --remove
+    python ocdskingfisher-views-cli field-counts viewname --remove
 
 
 In order to make it run you faster you can define how many threads it runs with.
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli field-counts --threads 5
+    python ocdskingfisher-views-cli field-counts viewname --threads 5
 
-
-By default, the command will run on the main "views" schema. If you have added extra views, and want it to run on those, pass the name as an option:
-
-.. code-block:: shell-session
-
-    python ocdskingfisher-views-cli field-counts --viewname test1

--- a/docs/cli-refresh-views.rst
+++ b/docs/cli-refresh-views.rst
@@ -5,13 +5,15 @@ This tool will refresh all the views in the views schema.
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli refresh-views
+    python ocdskingfisher-views-cli refresh-views viewname
 
-To remove all the views run:
+You must pass the view name.
+
+To remove all the tables run:
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli refresh-views --remove
+    python ocdskingfisher-views-cli refresh-views viewname --remove
 
 
 It has several options to make modifying the views easier to work with.
@@ -22,7 +24,7 @@ You can set the start and end number (inclusive) of the SQL scripts that you wan
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli refresh-views --start 4 --end 5
+    python ocdskingfisher-views-cli refresh-views viewname --start 4 --end 5
 
 This will run scripts ``004-planning.sql`` and ``005-tender.sql``.  Without ``--start`` the scripts will run from the start and without ``--end`` they will run to the end```
 
@@ -30,10 +32,5 @@ If you want to see the output of what SQL will be run without actually executing
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-views-cli refresh-views --sql
+    python ocdskingfisher-views-cli refresh-views viewname --sql
 
-By default, the command will run on the main "views" schema. If you have added extra views, and want it to run on those, pass the name as an option:
-
-.. code-block:: shell-session
-
-    python ocdskingfisher-views-cli refresh-views --viewname test1

--- a/docs/requirements-install.rst
+++ b/docs/requirements-install.rst
@@ -24,9 +24,9 @@ Set up a venv and install requirements::
 
 You need to configure the app: :doc:`config`
 
-A schema called ``views`` need to be set up in the Kingfisher Process database with the same owner as the database.
+Schemas called ``views``, ``view_info`` and ``view_meta`` need to be set up in the Kingfisher Process database with the same owner as the database.
 
-To use extra views, the database user must be able to create schema's at will.
+The database user must be able to create schema's at will.
 
 Then you need to create the base schemas to make the views work see :doc:`cli-upgrade-database`::
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -3,20 +3,12 @@ Views
 
 This tool can create many Views, or Schemas, in your database. Each view can be built from a seperate set of data.
 
-The Default View
-----------------
+Views
+-----
 
-By default, a view is created called ``views``.
+You can create views. Each one is in it's own Postgres schema and can contain data for 1 or more collections - you specify the exact ID's when creating the view.
 
-This is a special one, in that the collections it has data for consist of the latest version of each collection in the process database.
-It also includes any extra collections you add to ``extra_collections`` table in ``views`` schema.
-
-Extra Views
------------
-
-You can create extra views. Each one is in it's own Postgres schema and can contain data for 1 or more collections - you specify the exact ID's when creating the view.
-
-The build process for extra views can happen totally independently for the build process for the default views, and thus it can be triggered as soon as a collection is ready.
+The build process for each view can happen totally independently from other views, and thus it can be triggered as soon as a collection is ready.
 
 Use the :doc:`cli-add-view`  command to add a view.
 
@@ -26,22 +18,19 @@ This may take a long time, and you may want to run it via ``tmux`` or similar.
 Querying
 --------
 
-
-Views can be found in the postgres schema `views` within ocdskingfisher database
-(or the schema  ``view_data_ + the name you set``).
-In order to use them you can prefix the view with schema.
+Views can be found in the postgres schema ``view_data_ + the name you set`` within ocdskingfisher database.
 
 .. code-block:: postgresql
 
-    select * from views.release_summary;
+    select * from view_data_test.release_summary;
 
 Alternatively you can run
 
 .. code-block:: postgresql
 
-    set search_path = views, public;
+    set search_path = view_data_test, public;
 
-at the start of your sql script meaning that posgres will first look at the `views` schema then at kingfisher-process (which lives in the public schema) so that you can just do:
+at the start of your sql script meaning that Postgres will first look at the ``view_data_test`` schema then at kingfisher-process (which lives in the ``public`` schema) so that you can just do:
 
 .. code-block:: postgresql
 
@@ -52,7 +41,7 @@ at the start of your sql script meaning that posgres will first look at the `vie
 Structure
 ---------
 
-The set of tables that end with "_summary" all have key named ``id``.
+The set of tables that end with ``_summary`` all have key named ``id``.
 
 This ``id`` represents either a release, compiled_release (compiled by kingfisher) or record, and is unique across these types. There is ``release_type`` in the tables to say what type it is.
 
@@ -60,8 +49,8 @@ For a record the ``compiledRelease`` within it is used in the summary tables.
 
 
 
-Changing and rerunning Extra Views after creation
--------------------------------------------------
+Changing and rerunning views after creation
+-------------------------------------------
 
 Every schema has a ``selected_collections`` table. After a view has been created, you can still change what collections it contains by editing the contents of this table directly.
 

--- a/ocdskingfisherviews/cli/commands/add_view.py
+++ b/ocdskingfisherviews/cli/commands/add_view.py
@@ -43,11 +43,11 @@ class AddViewCLICommand(ocdskingfisherviews.cli.commands.base.CLICommand):
         if not args.dontbuild:
 
             logger.info("Refreshing Views after Creating View " + args.name)
-            refresh_views(engine, viewname=args.name)
+            refresh_views(engine, args.name)
 
             logger.info("Updating Field Counts after Creating View " + args.name)
             field_counts = FieldCounts(engine=engine)
-            field_counts.run(viewname=args.name)
+            field_counts.run(args.name)
 
             # This must be done after table creation in refresh_views and FieldCounts
             # as the users are granted access to tables that already exist.

--- a/ocdskingfisherviews/cli/commands/field_counts.py
+++ b/ocdskingfisherviews/cli/commands/field_counts.py
@@ -8,15 +8,15 @@ class FieldCountsCommand(ocdskingfisherviews.cli.commands.base.CLICommand):
     command = 'field-counts'
 
     def configure_subparser(self, subparser):
+        subparser.add_argument("viewname", help="Name Of View")
         subparser.add_argument("--remove", help="Aemove field_count table", action='store_true')
         subparser.add_argument("--threads", help="Amount of threads to use", type=int, default=1)
 
         subparser.add_argument("--logfile", help="Add psql timing to sql output")
-        subparser.add_argument("--viewname", help="optional view name")
 
     def run_logged_command(self, args):
 
         engine = sa.create_engine(self.config.database_uri)
 
         field_counts = FieldCounts(engine=engine)
-        field_counts.run(viewname=args.viewname, remove=args.remove, threads=args.threads)
+        field_counts.run(args.viewname, remove=args.remove, threads=args.threads)

--- a/ocdskingfisherviews/cli/commands/refresh_views.py
+++ b/ocdskingfisherviews/cli/commands/refresh_views.py
@@ -8,6 +8,7 @@ class RefreshCLICommand(ocdskingfisherviews.cli.commands.base.CLICommand):
     command = 'refresh-views'
 
     def configure_subparser(self, subparser):
+        subparser.add_argument("viewname", help="Name Of View")
         subparser.add_argument("--remove", help="remove all views", action='store_true')
         subparser.add_argument("--start", type=int, default=0,
                                help="Start at script. i.e 4 will start at 004-planning.sql")
@@ -16,16 +17,15 @@ class RefreshCLICommand(ocdskingfisherviews.cli.commands.base.CLICommand):
         subparser.add_argument("--sql", help="Just output sql and do not run", action='store_true')
         subparser.add_argument("--sql-timing", help="Add psql timing to sql output", action='store_true')
         subparser.add_argument("--logfile", help="optional output logfile")
-        subparser.add_argument("--viewname", help="optional view name")
 
     def run_logged_command(self, args):
 
         engine = sa.create_engine(self.config.database_uri)
 
         refresh_views(engine,
+                      args.viewname,
                       remove=args.remove,
                       start=args.start,
                       end=args.end,
                       sql=args.sql,
-                      sql_timing=args.sql_timing,
-                      viewname=args.viewname)
+                      sql_timing=args.sql_timing)

--- a/ocdskingfisherviews/field_counts.py
+++ b/ocdskingfisherviews/field_counts.py
@@ -42,14 +42,11 @@ class FieldCounts():
                 connection.execute('insert into field_counts_temp values (%s, %s, %s, %s, %s, %s)', *results)
             logger.info('running time for collection {}: {}s'.format(collection, timer() - start))
 
-    def run(self, viewname=None, remove=False, threads=1):
+    def run(self, viewname, remove=False, threads=1):
 
-        if viewname:
-            # Technically this is SQL injection opportunity,
-            # but as operators have access to the DB anyway we don't care.
-            self.search_path_string = 'set search_path = view_data_'+viewname+', public;'
-        else:
-            self.search_path_string = 'set search_path = views, public;'
+        # Technically this is SQL injection opportunity,
+        # but as operators have access to the DB anyway we don't care.
+        self.search_path_string = 'set search_path = view_data_'+viewname+', public;'
 
         overall_start = timer()
 

--- a/ocdskingfisherviews/refresh_views.py
+++ b/ocdskingfisherviews/refresh_views.py
@@ -6,7 +6,7 @@ from timeit import default_timer as timer
 from logzero import logger
 
 
-def refresh_views(engine, remove=False, start=0, end=1000, sql=False, sql_timing=False, viewname=None):
+def refresh_views(engine, viewname, remove=False, start=0, end=1000, sql=False, sql_timing=False):
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
     sql_scripts_path = os.path.join(dir_path, '../sql')
@@ -51,12 +51,9 @@ def refresh_views(engine, remove=False, start=0, end=1000, sql=False, sql_timing
 
         for statement_part in statement_parts:
             with engine.begin() as connection:
-                if viewname:
-                    # Technically this is SQL injection opportunity,
-                    # but as operators have access to the DB anyway we don't care.
-                    connection.execute('set search_path = view_data_' + viewname + ', public;\n')
-                else:
-                    connection.execute('set search_path = views, public;\n')
+                # Technically this is SQL injection opportunity,
+                # but as operators have access to the DB anyway we don't care.
+                connection.execute('set search_path = view_data_' + viewname + ', public;\n')
                 connection.execute(statement_part, tuple())
 
         logger.info('running time: {}s'.format(timer() - start))

--- a/tests/test_refresh_view.py
+++ b/tests/test_refresh_view.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 import sqlalchemy as sa
 
@@ -44,38 +46,48 @@ VIEWS_TABLES = {
 
 
 def test_refresh_runs(engine):
-    run_command(['refresh-views', '--remove'])
-    run_command(['refresh-views'])
-    get_current_tables_query = "select table_name from information_schema.tables where table_schema = 'views'"
+    viewname = 'viewname' + str(random.randint(1, 10000000))
+    run_command(['add-view', viewname, '1', 'Note'])
+    run_command(['refresh-views', viewname, '--remove'])
+    run_command(['refresh-views', viewname])
+    get_current_tables_query = "select table_name from information_schema.tables " + \
+                               "where table_schema = 'view_data_" + viewname + "'"
 
     with engine.connect() as conn:
         results = conn.execute(get_current_tables_query)
         db_tables = {result['table_name'] for result in results}
         assert db_tables.issuperset(VIEWS_TABLES)
 
-    run_command(['refresh-views', '--remove'])
+    run_command(['refresh-views', viewname, '--remove'])
     with engine.connect() as conn:
         results = conn.execute(get_current_tables_query)
         db_tables = {result['table_name'] for result in results}
         assert db_tables.isdisjoint(VIEWS_TABLES)
 
+    run_command(['delete-view', viewname])
+
 
 def test_field_count_runs(engine):
-    run_command(['refresh-views', '--remove'])
-    run_command(['field-counts', '--remove'])
-    run_command(['refresh-views'])
-    run_command(['field-counts'])
-    get_current_tables_query = "select table_name from information_schema.tables where table_schema = 'views'"
+    viewname = 'viewname' + str(random.randint(1, 10000000))
+    run_command(['add-view', viewname, '1', 'Note'])
+    run_command(['refresh-views', viewname, '--remove'])
+    run_command(['field-counts', viewname, '--remove'])
+    run_command(['refresh-views', viewname])
+    run_command(['field-counts', viewname])
+    get_current_tables_query = "select table_name from information_schema.tables " + \
+                               "where table_schema = 'view_data_" + viewname + "'"
 
     with engine.connect() as conn:
         results = conn.execute(get_current_tables_query)
         db_tables = {result['table_name'] for result in results}
         assert 'field_counts' in db_tables
 
-    run_command(['refresh-views', '--remove'])
-    run_command(['field-counts', '--remove'])
+    run_command(['refresh-views', viewname, '--remove'])
+    run_command(['field-counts', viewname, '--remove'])
 
     with engine.connect() as conn:
         results = conn.execute(get_current_tables_query)
         db_tables = {result['table_name'] for result in results}
         assert 'field_counts' not in db_tables
+
+    run_command(['delete-view', viewname])


### PR DESCRIPTION
* field-counts and refresh-views - viewname is now required

(We still leave tables in the views schema in place; we must check it's okay to delete that before we do so.)