### PR TITLE
SQL: Fix so data shows in release_summary_with_data

### DIFF
--- a/sql/002-tmp_release_and_parties.sql
+++ b/sql/002-tmp_release_and_parties.sql
@@ -64,6 +64,7 @@ select
     ocid,
     null AS release_id,
     data_id,
+    --Kingfisher Process’ compiled_release table has no package_data_id column, so setting package_data_id to null.
     null AS package_data_id,
     null AS package_version,  -- this would be useful but hard to get
     convert_to_timestamp(d.data ->> 'date') release_date,

--- a/sql/008-release.sql
+++ b/sql/008-release.sql
@@ -347,8 +347,10 @@ join
     data d on d.id = rs.data_id
 join 
     collection c on c.id = rs.collection_id 
-join
-    package_data pd on pd.id = rs.package_data_id;
+--Kingfisher Process’ compiled_release table has no package_data_id column.
+--Therefore, any rows in release_summary sourced from that table will have a NULL package_data_id.
+left join
+    package_data pd on pd.id = rs.package_data_id ;
 
 
 drop view if exists release_summary_with_checks;


### PR DESCRIPTION
Make package_data left join as merged releaes do not have a package_data_id.