### PR TITLE
Comments - Add comment to each query run.

### DIFF
--- a/ocdskingfisherviews/field_counts.py
+++ b/ocdskingfisherviews/field_counts.py
@@ -3,6 +3,8 @@ import logging
 from timeit import default_timer as timer
 
 field_count_query = '''
+    /*kingfisher-views field-counts*/
+
     set parallel_tuple_cost=0.00001;
     set parallel_setup_cost=0.00001;
     set work_mem='10MB';

--- a/ocdskingfisherviews/refresh_views.py
+++ b/ocdskingfisherviews/refresh_views.py
@@ -4,6 +4,8 @@ import os
 from collections import OrderedDict
 from timeit import default_timer as timer
 
+COMMENT = '/*kingfisher-views refresh-views*/\n'
+
 
 def refresh_views(engine, viewname, remove=False):
     logger = logging.getLogger('ocdskingfisher.views.refresh-views')
@@ -43,7 +45,7 @@ def refresh_views(engine, viewname, remove=False):
             with engine.begin() as connection:
                 schema_name = engine.dialect.identifier_preparer.quote('view_data_' + viewname)
                 connection.execute('SET search_path = {}, public;'.format(schema_name))
-                connection.execute(statement_part, tuple())
+                connection.execute(COMMENT + statement_part, tuple())
 
         logger.info('running time: {}s'.format(timer() - start))
 


### PR DESCRIPTION
This is to make it easier to see what is running the queries.

Fixes https://github.com/open-contracting/kingfisher-views/issues/66