### PR TITLE
flatten: Use UNION instead of subquery

### DIFF
--- a/sql/extras/flatten.sql
+++ b/sql/extras/flatten.sql
@@ -6,65 +6,70 @@ CREATE OR REPLACE FUNCTION flatten (jsonb)
     LANGUAGE 'sql'
     PARALLEL SAFE
     AS $$
-    WITH RECURSIVE all_paths (
-        path,
-        "value",
-        "object_property",
-        "array_item"
-) AS (
+    -- https://www.postgresql.org/docs/current/queries-with.html
+    -- https://github.com/MaayanLab/signature-commons-metadata-api/blob/master/src/migration/1568055725225-jsonb-deep-key-value.ts
+    WITH RECURSIVE t (
+        KEY,
+        value,
+        object_property,
+        array_item
+    ) AS (
         SELECT
-            KEY "path",
-            value "value",
-            1 "object_property",
-            0 "array_item"
+            j.key,
+            j.value,
+            1,
+            0
         FROM
-            jsonb_each($1)
+            jsonb_each($1) AS j
         UNION ALL (
-            SELECT
-                CASE WHEN key_value IS NOT NULL THEN
-                    path || '/'::text || (key_value).KEY::text
-                ELSE
-                    path
-                END "path",
-                CASE WHEN key_value IS NOT NULL THEN
-                (key_value).value
-            ELSE
-                array_value
-                END "value",
-                CASE WHEN key_value IS NOT NULL THEN
-                    1
-                ELSE
-                    0
-                END,
-                CASE WHEN key_value IS NULL THEN
-                    1
-                ELSE
-                    0
-                END
-            FROM (
+            WITH prev AS (
                 SELECT
-                    path,
-                    jsonb_each(
-                        CASE WHEN jsonb_typeof(value) = 'object' THEN
-                            value
-                        ELSE
-                            '{}'::jsonb
-                        END) key_value,
-                    jsonb_array_elements(
-                        CASE WHEN jsonb_typeof(value) = 'array'
-                            AND jsonb_typeof(value -> 0) = 'object' THEN
-                            value
-                        ELSE
-                            '[]'::jsonb
-                        END) "array_value"
+                    *
                 FROM
-                    all_paths) a))
-SELECT
-    path,
-    object_property,
-    array_item
-FROM
-    all_paths;
+                    t -- recursive reference to query "t" must not appear more than once
+            ),
+            obj AS (
+                SELECT
+                    prev.key || '/' || tt.key,
+                    tt.value,
+                    1,
+                    0
+                FROM
+                    prev,
+                    jsonb_each(prev.value) tt
+                WHERE
+                    jsonb_typeof(prev.value) = 'object'
+            ),
+            arr AS (
+                SELECT
+                    prev.key,
+                    tt.value,
+                    0,
+                    1
+                FROM
+                    prev,
+                    jsonb_array_elements(prev.value) tt
+                WHERE
+                    jsonb_typeof(prev.value) = 'array'
+                    AND jsonb_typeof(prev.value -> 0) = 'object'
+            )
+            SELECT
+                *
+            FROM
+                obj
+            UNION ALL
+            SELECT
+                *
+            FROM
+                arr
+        )
+    )
+    SELECT
+        KEY AS path,
+        object_property,
+        array_item
+    FROM
+        t;
 
 $$;
 

--- a/sql/extras/flatten.sql
+++ b/sql/extras/flatten.sql
@@ -7,9 +7,8 @@ CREATE OR REPLACE FUNCTION flatten (jsonb)
     PARALLEL SAFE
     AS $$
     -- https://www.postgresql.org/docs/current/queries-with.html
-    -- https://github.com/MaayanLab/signature-commons-metadata-api/blob/master/src/migration/1568055725225-jsonb-deep-key-value.ts
     WITH RECURSIVE t (
-        KEY,
+        key,
         value,
         object_property,
         array_item
@@ -65,7 +64,7 @@ CREATE OR REPLACE FUNCTION flatten (jsonb)
         )
     )
     SELECT
-        KEY AS path,
+        key AS path,
         object_property,
         array_item
     FROM
@@ -83,66 +82,69 @@ CREATE OR REPLACE FUNCTION flatten_with_values (jsonb)
     LANGUAGE 'sql'
     PARALLEL SAFE
     AS $$
-    WITH RECURSIVE all_paths (
-        path,
-        "value",
-        "object_property",
-        "array_item"
-) AS (
+    WITH RECURSIVE t (
+        key,
+        value,
+        object_property,
+        array_item
+    ) AS (
         SELECT
-            KEY "path",
-            value "value",
-            1 "object_property",
-            0 "array_item"
+            j.key,
+            j.value,
+            1,
+            0
         FROM
-            jsonb_each($1)
+            jsonb_each($1) AS j
         UNION ALL (
-            SELECT
-                CASE WHEN key_value IS NOT NULL THEN
-                    path || '/'::text || (key_value).KEY::text
-                ELSE
-                    path
-                END "path",
-                CASE WHEN key_value IS NOT NULL THEN
-                (key_value).value
-            ELSE
-                array_value
-                END "value",
-                CASE WHEN key_value IS NOT NULL THEN
-                    1
-                ELSE
-                    0
-                END,
-                CASE WHEN key_value IS NULL THEN
-                    1
-                ELSE
-                    0
-                END
-            FROM (
+            WITH prev AS (
                 SELECT
-                    path,
-                    jsonb_each(
-                        CASE WHEN jsonb_typeof(value) = 'object' THEN
-                            value
-                        ELSE
-                            '{}'::jsonb
-                        END) key_value,
-                    jsonb_array_elements(
-                        CASE WHEN jsonb_typeof(value) = 'array'
-                            AND jsonb_typeof(value -> 0) = 'object' THEN
-                            value
-                        ELSE
-                            '[]'::jsonb
-                        END) "array_value"
+                    *
                 FROM
-                    all_paths) a))
-SELECT
-    path,
-    object_property,
-    array_item,
-    value
-FROM
-    all_paths;
+                    t -- recursive reference to query "t" must not appear more than once
+            ),
+            obj AS (
+                SELECT
+                    prev.key || '/' || tt.key,
+                    tt.value,
+                    1,
+                    0
+                FROM
+                    prev,
+                    jsonb_each(prev.value) tt
+                WHERE
+                    jsonb_typeof(prev.value) = 'object'
+            ),
+            arr AS (
+                SELECT
+                    prev.key,
+                    tt.value,
+                    0,
+                    1
+                FROM
+                    prev,
+                    jsonb_array_elements(prev.value) tt
+                WHERE
+                    jsonb_typeof(prev.value) = 'array'
+                    AND jsonb_typeof(prev.value -> 0) = 'object'
+            )
+            SELECT
+                *
+            FROM
+                obj
+            UNION ALL
+            SELECT
+                *
+            FROM
+                arr
+        )
+    )
+    SELECT
+        key AS path,
+        object_property,
+        array_item,
+        value
+    FROM
+        t;
 
 $$;
 


### PR DESCRIPTION
Closes #159 

The style from https://github.com/fhirbase/master-class/blob/93692db5094e1ca56aba7c0adb671fa6104f4e3e/sql-result
 that just does a simple UNION is 15-20% faster.